### PR TITLE
Fix: reliable long-press for flagging; prevent iOS context menu

### DIFF
--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -14,30 +14,20 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
 
   const getNumberedCellColour = (number: number) => {
     switch (number) {
-      case 1:
-        return { color: "blue" };
-      case 2:
-        return { color: "green" };
-      case 3:
-        return { color: "red" };
-      case 4:
-        return { color: "darkblue" };
-      case 5:
-        return { color: "brown" };
-      case 6:
-        return { color: "lightblue" };
-      case 7:
-        return { color: "purple" };
-      case 8:
-        return { color: "pink" };
-      default:
-        return { color: "black" };
+      case 1: return { color: "blue" };
+      case 2: return { color: "green" };
+      case 3: return { color: "red" };
+      case 4: return { color: "darkblue" };
+      case 5: return { color: "brown" };
+      case 6: return { color: "lightblue" };
+      case 7: return { color: "purple" };
+      case 8: return { color: "pink" };
+      default: return { color: "black" };
     }
   };
 
   const renderCellContents = () => {
     if (!cell.isRevealed && !cell.isFlagged) return null;
-
     if (cell.isIncorrectlyFlagged) {
       return (
         <span data-testid="x-icon">
@@ -45,13 +35,8 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
         </span>
       );
     }
-
-    if (cell.isFlagged) {
-      return <Flag size={20} color="#c01c28" weight="fill" />;
-    }
-    if (cell.hasMine) {
-      return <Bomb size={20} weight="fill" />;
-    }
+    if (cell.isFlagged) return <Flag size={20} color="#c01c28" weight="fill" />;
+    if (cell.hasMine) return <Bomb size={20} weight="fill" />;
     if (cell.adjacentMinesCount > 0) {
       const number = cell.adjacentMinesCount;
       return <span style={getNumberedCellColour(number)}>{number}</span>;
@@ -59,18 +44,13 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
     return null;
   };
 
-  // Desktop right-click should still toggle flag:
-  const handleContextMenu: React.MouseEventHandler<HTMLDivElement> = (e) => {
-    e.preventDefault();
-    onContextMenu?.(e);
-  };
-
-  // Mobile long-press → call the same toggle-flag handler.
-  // We invoke onContextMenu with a synthetic event to reuse upstream logic.
+  // Use long-press hook:
+  // - On mobile: triggers onContextMenu after long press
+  // - On desktop: triggers onContextMenu on right-click
+  // Prevents double invocation by not attaching onContextMenu directly
   const longPress = useLongPress(() => {
     if (onContextMenu) {
       const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-      // cast as any to satisfy React's type (we only need the callback)
       onContextMenu(evt as any);
     }
   }, 450);
@@ -83,7 +63,6 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
       data-row={cell.x}
       data-col={cell.y}
       onClick={onClick}
-      onContextMenu={handleContextMenu}
     >
       {renderCellContents()}
     </div>

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,6 +1,7 @@
-import classNames from 'classnames';
-import { Bomb, X, Flag } from '@phosphor-icons/react';
-import type { CellProps } from './Cell.interfaces';
+import classNames from "classnames";
+import { Bomb, X, Flag } from "@phosphor-icons/react";
+import type { CellProps } from "./Cell.interfaces";
+import useLongPress from "../hooks/useLongPress";
 
 function Cell({ cell, onClick, onContextMenu }: CellProps) {
   const cellClass = classNames({
@@ -14,23 +15,23 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
   const getNumberedCellColour = (number: number) => {
     switch (number) {
       case 1:
-        return { color: 'blue' };
+        return { color: "blue" };
       case 2:
-        return { color: 'green' };
+        return { color: "green" };
       case 3:
-        return { color: 'red' };
+        return { color: "red" };
       case 4:
-        return { color: 'darkblue' };
+        return { color: "darkblue" };
       case 5:
-        return { color: 'brown' };
+        return { color: "brown" };
       case 6:
-        return { color: 'lightblue' };
+        return { color: "lightblue" };
       case 7:
-        return { color: 'purple' };
+        return { color: "purple" };
       case 8:
-        return { color: 'pink' };
+        return { color: "pink" };
       default:
-        return { color: 'black' };
+        return { color: "black" };
     }
   };
 
@@ -39,32 +40,50 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
 
     if (cell.isIncorrectlyFlagged) {
       return (
-        <span data-testid='x-icon'>
-          <X size={20} color='#c01c28' weight='bold' />
+        <span data-testid="x-icon">
+          <X size={20} color="#c01c28" weight="bold" />
         </span>
       );
     }
 
     if (cell.isFlagged) {
-      return <Flag size={20} color='#c01c28' weight='fill' />;
+      return <Flag size={20} color="#c01c28" weight="fill" />;
     }
     if (cell.hasMine) {
-      return <Bomb size={20} weight='fill' />;
+      return <Bomb size={20} weight="fill" />;
     }
     if (cell.adjacentMinesCount > 0) {
       const number = cell.adjacentMinesCount;
       return <span style={getNumberedCellColour(number)}>{number}</span>;
     }
+    return null;
   };
+
+  // Desktop right-click should still toggle flag:
+  const handleContextMenu: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    e.preventDefault();
+    onContextMenu?.(e);
+  };
+
+  // Mobile long-press → call the same toggle-flag handler.
+  // We invoke onContextMenu with a synthetic event to reuse upstream logic.
+  const longPress = useLongPress(() => {
+    if (onContextMenu) {
+      const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+      // cast as any to satisfy React's type (we only need the callback)
+      onContextMenu(evt as any);
+    }
+  }, 450);
 
   return (
     <div
+      ref={longPress.ref as any}
       className={cellClass}
-      data-testid='cell'
+      data-testid="cell"
       data-row={cell.x}
       data-col={cell.y}
       onClick={onClick}
-      onContextMenu={onContextMenu}
+      onContextMenu={handleContextMenu}
     >
       {renderCellContents()}
     </div>

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,21 +1,28 @@
-import type { CSSProperties } from 'react';
-import Cell from './Cell';
-import type { GameBoardProps } from './GameBoard.interfaces';
+import type { CSSProperties } from "react";
+import Cell from "./Cell";
+import type { GameBoardProps } from "./GameBoard.interfaces";
 
-function GameBoard({
-  board,
-  boardSize,
-  onClick,
-  onContextMenu,
-}: GameBoardProps) {
-  // CSS custom properties to control the grid layout
+function GameBoard({ board, boardSize, onClick, onContextMenu }: GameBoardProps) {
   const style = {
-    '--rows': `${boardSize.rowCount}`,
-    '--columns': `${boardSize.columnCount}`,
+    "--rows": `${boardSize.rowCount}`,
+    "--columns": `${boardSize.columnCount}`,
   } as CSSProperties;
 
+  // Hardening against iOS callout/selection on the grid container
+  const boardInteractionStyle: React.CSSProperties = {
+    WebkitTouchCallout: "none",
+    WebkitUserSelect: "none",
+    userSelect: "none",
+    touchAction: "manipulation",
+  };
+
   return (
-    <div style={style} className='board' id='board' data-testid='game-board'>
+    <div
+      style={{ ...style, ...boardInteractionStyle }}
+      className="board"
+      id="board"
+      data-testid="game-board"
+    >
       {board.map((rows, rowIndex) =>
         rows.map((_, colIndex) => (
           <Cell

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from "react";
+
+type Callback = () => void;
+
+/**
+ * Cross-platform long-press hook.
+ *
+ * Purpose:
+ * - Provides a consistent "long-press" behavior across Desktop, Android, and iOS.
+ * - On Desktop: intercepts the `contextmenu` event to simulate a right-click action without showing the native menu.
+ * - On Mobile (Android/iOS): a quick tap still triggers the normal `onClick`; a long-press calls the provided callback.
+ * - On iOS Safari: prevents the native "Copy / Select" context menu when a long-press is detected.
+ *
+ * Parameters:
+ * @param cb - Callback executed when a long-press is detected.
+ * @param ms - Duration threshold (in ms) to qualify as a long-press. Defaults to 450ms.
+ *
+ * Usage:
+ * const longPress = useLongPress(() => toggleFlag(cell), 450);
+ * <div ref={longPress.ref} onClick={onClick}>...</div>
+ */
+export default function useLongPress(cb: Callback, ms = 450) {
+    // Ref to the element where long-press detection will be attached
+    const ref = useRef<HTMLElement | null>(null);
+
+    // Timer used to measure how long the touch/press has been held
+    const timer = useRef<number | null>(null);
+
+    // Flag to track if the last interaction was a long-press
+    const didLongPress = useRef(false);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+
+        /**
+         * Touch start handler
+         * - Resets the long-press state.
+         * - Starts the timer; if held long enough, triggers the callback and marks as long-press.
+         */
+        const onTouchStart = () => {
+            didLongPress.current = false;
+            timer.current = window.setTimeout(() => {
+                cb();
+                didLongPress.current = true;
+            }, ms);
+        };
+
+        /**
+         * Touch end handler
+         * - Clears the timer.
+         * - If the press was long enough, prevents the subsequent synthetic "click"
+         *   so that the action doesn't trigger twice (once for long-press, once for click).
+         */
+        const onTouchEnd = (e: TouchEvent) => {
+            if (timer.current) window.clearTimeout(timer.current);
+            timer.current = null;
+
+            if (didLongPress.current) {
+                e.preventDefault(); // Cancel the default click after long-press
+                didLongPress.current = false;
+            }
+        };
+
+        /**
+         * Context menu handler
+         * - Captures right-click on Desktop and prevents the browser's context menu from appearing.
+         * - Calls the callback to simulate the flagging action (or any custom logic).
+         */
+        const onContextMenu = (e: Event) => {
+            e.preventDefault();
+            cb();
+        };
+
+        // Attach event listeners
+        el.addEventListener("touchstart", onTouchStart, { passive: true });
+        el.addEventListener("touchend", onTouchEnd);
+        el.addEventListener("contextmenu", onContextMenu);
+
+        // Cleanup listeners on unmount
+        return () => {
+            el.removeEventListener("touchstart", onTouchStart as any);
+            el.removeEventListener("touchend", onTouchEnd as any);
+            el.removeEventListener("contextmenu", onContextMenu as any);
+        };
+    }, [cb, ms]);
+
+    return { ref };
+}


### PR DESCRIPTION
This PR fixes long-press not working reliably across devices.

✅ Tested on:
- **Desktop Chrome**: left click = reveal, right click = flag (unchanged).
- **Android Chrome**: tap = reveal, long-press = flag (works as expected).

<img width="811" height="228" alt="image" src="https://github.com/user-attachments/assets/c59b7e7b-d73e-4f25-aa58-8c99b2a7472c" />

⚠️ iOS:
I don’t have an iOS device available.  
The fix prevents Safari’s native context menu by intercepting `contextmenu` and canceling the synthetic click **only when a true long-press occurred**. Requesting confirmation from maintainers on iOS Safari.

---

### Changes
- Added new hook `useLongPress` to handle `touchstart`, `touchend`, and `contextmenu` consistently.
- Integrated the hook into `Cell` so long-press triggers the same logic as right-click without duplicate calls.
- Removed direct `onContextMenu` binding on the cell `div` to avoid double invocations.
- Preserved existing `onClick` behavior for quick taps (desktop + mobile).

### Notes
- All unit tests now pass (fixed the double contextmenu issue).
- No tooling/config changes included; local LAN testing was done using `vite --host`.

---

Closes #60
