### PR TITLE
Fix accessibility issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -106,6 +106,7 @@ dialog p {
   overflow-y: hidden;
   justify-content: flex-start;
   margin: 5px;
+  padding: 2px 0;
 }
 
 #board {
@@ -149,6 +150,11 @@ dialog p {
   position: relative;
   border-radius: 5px;
   font-size: 16px;
+}
+
+.cell:focus {
+  outline: 2px solid #0066cc;
+  z-index: 1;
 }
 
 .cell:hover {

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -57,6 +57,22 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
     }
   };
 
+  const getAriaLabel = () => {
+    if (cell.isFlagged) {
+      return 'Flagged cell';
+    }
+    if (cell.isRevealed) {
+      if (cell.hasMine) {
+        return cell.hasExplodedMine ? 'Exploded mine' : 'Mine';
+      }
+      if (cell.adjacentMinesCount > 0) {
+        return `Cell with ${cell.adjacentMinesCount} adjacent mine${cell.adjacentMinesCount === 1 ? '' : 's'}`;
+      }
+      return 'Empty revealed cell';
+    }
+    return 'Unrevealed cell';
+  };
+
   return (
     <button
       type='button'
@@ -65,11 +81,10 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
       data-row={cell.x}
       data-col={cell.y}
       onClick={onClick}
-      aria-label={
-        cell.isFlagged ? 'Flag' : cell.adjacentMinesCount?.toString() || 'Empty'
-      }
-      aria-pressed={cell.isFlagged || undefined}
-      aria-disabled={cell.isRevealed} 
+      role='gridcell'
+      aria-label={getAriaLabel()}
+      aria-pressed={cell.isFlagged ? true : false}
+      aria-disabled={cell.isRevealed}
       onContextMenu={onContextMenu}
     >
       {renderCellContents()}

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -58,7 +58,7 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
   };
 
   return (
-    <div
+    <button
       className={cellClass}
       data-testid='cell'
       data-row={cell.x}
@@ -67,7 +67,7 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
       onContextMenu={onContextMenu}
     >
       {renderCellContents()}
-    </div>
+    </button>
   );
 }
 

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -59,11 +59,17 @@ function Cell({ cell, onClick, onContextMenu }: CellProps) {
 
   return (
     <button
+      type='button'
       className={cellClass}
       data-testid='cell'
       data-row={cell.x}
       data-col={cell.y}
       onClick={onClick}
+      aria-label={
+        cell.isFlagged ? 'Flag' : cell.adjacentMinesCount?.toString() || 'Empty'
+      }
+      aria-pressed={cell.isFlagged || undefined}
+      aria-disabled={cell.isRevealed} 
       onContextMenu={onContextMenu}
     >
       {renderCellContents()}

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -15,7 +15,14 @@ function GameBoard({
   } as CSSProperties;
 
   return (
-    <div style={style} className='board' id='board' data-testid='game-board'>
+    <div
+      style={style}
+      className='board'
+      id='board'
+      data-testid='game-board'
+      role='grid'
+      aria-label={`Minesweeper grid ${boardSize.rowCount} by ${boardSize.columnCount}`}
+    >
       {board.map((rows, rowIndex) =>
         rows.map((_, colIndex) => (
           <Cell

--- a/src/components/GameDifficultySelector.tsx
+++ b/src/components/GameDifficultySelector.tsx
@@ -13,22 +13,27 @@ function GameDifficultySelector({
 }: GameDifficultySelectorProps) {
   return (
     <div className='game-difficulty-select-wrapper'>
-      <label>Difficulty: </label>
+      <label htmlFor='game-difficulty-select'>Difficulty: </label>
       <select
         value={gameDifficultySettings.level}
         onChange={onChange}
         name='game-difficulty-select'
         id='game-difficulty-select'
         data-testid='difficulty-select'
+        aria-describedby='difficulty-description'
       >
-        {gameDifficultyLevelKeys.map((setting) => (
-          <option
-            key={setting}
-            value={GAME_DIFFICULTY_LEVEL_SETTINGS[setting].level}
-          >
-            {GAME_DIFFICULTY_LEVEL_SETTINGS[setting].label}
-          </option>
-        ))}
+        {gameDifficultyLevelKeys.map((setting) => {
+          const config = GAME_DIFFICULTY_LEVEL_SETTINGS[setting];
+          return (
+            <option
+              key={setting}
+              value={config.level}
+              aria-label={`${config.label} - ${config.boardSize.rowCount}x${config.boardSize.columnCount} board with ${config.mineCount} mines`}
+            >
+              {config.label}
+            </option>
+          );
+        })}
       </select>
     </div>
   );

--- a/src/components/GameResultModal.tsx
+++ b/src/components/GameResultModal.tsx
@@ -28,9 +28,15 @@ function GameResultModal({ gameWon, onClick }: GameResultModalProps) {
       id='gameResultModal'
       className={modalClass}
       data-testid='result-modal'
+      aria-labelledby='game-result-message'
+      aria-describedby='game-result-description'
     >
-      <p>{message}</p>
-      <button id='gameResultModalCloseButton' onClick={closeModal}>
+      <p id='game-result-message'>{message}</p>
+      <button
+        aria-label='Play again'
+        id='gameResultModalCloseButton'
+        onClick={closeModal}
+      >
         Play again
       </button>
     </dialog>

--- a/src/components/RemainingFlagsCounter.tsx
+++ b/src/components/RemainingFlagsCounter.tsx
@@ -1,5 +1,4 @@
 import { Flag } from '@phosphor-icons/react';
-import { AccessibleIcon } from '@radix-ui/react-accessible-icon';
 import { memo } from 'react';
 import type { RemainingFlagsCounterProps } from './RemainingFlagsCounter.interface';
 
@@ -8,9 +7,7 @@ function RemainingFlagsCounter({
 }: RemainingFlagsCounterProps) {
   return (
     <div id='remainingFlagsCounter' data-testid='flags-remaining'>
-      <AccessibleIcon label='flag icon'>
-        <Flag size={25} color='#c01c28' weight='fill' />
-      </AccessibleIcon>
+      <Flag size={25} color='#c01c28' weight='fill' aria-hidden='true' />
       <span id='remainingFlagsLabel'>Remaining Flags:</span>
       <span id='remainingFlagsCount'>{remainingFlagsCount}</span>
     </div>


### PR DESCRIPTION
- Adjusted the cell component to be wrapped with button instead of a div to make it more semantically correct.
- Added a role, label, aria-pressed, aria-disabled (so it can't be clicked but still tabbed through), and a getAriaLabel function (that returns if it's flagged, a mine, empty revealed cell, or how many bombs are adjacent to that cell.
- Small adjustment to GameResultModal to add aria labels
- Added aria labels to the game difficulty selector

Test these changes by pulling the branch, running the dev environment, and visiting the webpage.
Then tab through the entire board (suggest the beginner board)

See if there are any issues with tabbing and hitting enter, and see if there's any kind of problem with it allowing you to click or press the disabled buttons (ones that are already pressed/revealed).

If you want to go the extra mile with testing, install/setup a text to speech reader and have it read as you tab through the page/board.
