### PR TITLE
Renamed 2 components to DifficultySelect and ResultModal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect, useRef } from 'react';
 
 import { GAME_DIFFICULTY_LEVEL_SETTINGS } from '@config/gameDifficultyLevelSettings';
 
-import GameDifficultySelector from '@feature/GameDifficultySelector/GameDifficultySelector';
+import GameDifficultySelector from '@/components/feature/DifficultySelect/DifficultySelect';
 import GameBoard from '@feature/GameBoard/GameBoard';
-import GameResultModal from '@feature/GameResultModal/GameResultModal';
+import ResultModal from '@/components/feature/ResultModal/ResultModal';
 import RemainingFlagsCounter from '@feature/RemainingFlagsCounter/RemainingFlagsCounter';
 
 import {
@@ -273,10 +273,10 @@ function App() {
           remainingFlagsCount={remainingFlagsCount}
         ></RemainingFlagsCounter>
         {gameHasEnded() && (
-          <GameResultModal
+          <ResultModal
             gameWon={userWonGame()}
             onClick={onCloseGameResultModal}
-          ></GameResultModal>
+          ></ResultModal>
         )}
         <div id='boardContainer' ref={boardContainerRef}>
           <GameBoard

--- a/src/components/feature/DifficultySelect/DifficultySelect.interfaces.ts
+++ b/src/components/feature/DifficultySelect/DifficultySelect.interfaces.ts
@@ -1,6 +1,6 @@
 import type { GameDifficultyLevelSettings } from '@config/gameDifficultyLevelSettings.interfaces';
 
-export type GameDifficultySelectorProps = {
+export type DifficultySelectProps = {
   gameDifficultySettings: GameDifficultyLevelSettings[keyof GameDifficultyLevelSettings];
   onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
 };

--- a/src/components/feature/DifficultySelect/DifficultySelect.tsx
+++ b/src/components/feature/DifficultySelect/DifficultySelect.tsx
@@ -1,16 +1,16 @@
 import { GAME_DIFFICULTY_LEVEL_SETTINGS } from '@config/gameDifficultyLevelSettings';
 import { memo } from 'react';
 import type { GameDifficultyLevelKeys } from '@enum/GameDifficultyLevel.interfaces';
-import type { GameDifficultySelectorProps } from '@feature/GameDifficultySelector/GameDifficultySelector.interfaces'; 
+import type { DifficultySelectProps } from '@/components/feature/DifficultySelect/DifficultySelect.interfaces'; 
 
 const gameDifficultyLevelKeys = Object.keys(
   GAME_DIFFICULTY_LEVEL_SETTINGS
 ) as GameDifficultyLevelKeys[];
 
-function GameDifficultySelector({
+function DifficultySelect({
   gameDifficultySettings,
   onChange,
-}: GameDifficultySelectorProps) {
+}: DifficultySelectProps) {
   return (
     <div className='game-difficulty-select-wrapper'>
       <label htmlFor='game-difficulty-select'>Difficulty: </label>
@@ -39,4 +39,4 @@ function GameDifficultySelector({
   );
 }
 
-export default memo(GameDifficultySelector);
+export default memo(DifficultySelect);

--- a/src/components/feature/ResultModal/ResultModal.interface.ts
+++ b/src/components/feature/ResultModal/ResultModal.interface.ts
@@ -1,4 +1,4 @@
-export type GameResultModalProps = {
+export type ResultModalProps = {
   gameWon: boolean;
   onClick: () => void;
 };

--- a/src/components/feature/ResultModal/ResultModal.tsx
+++ b/src/components/feature/ResultModal/ResultModal.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 
 import classNames from 'classnames';
-import type { GameResultModalProps } from '@feature/GameResultModal/GameResultModal.interface';
+import type { ResultModalProps } from '@/components/feature/ResultModal/ResultModal.interface';
 
-function GameResultModal({ gameWon, onClick }: GameResultModalProps) {
+function ResultModal({ gameWon, onClick }: ResultModalProps) {
   const [modalStateClass, setModalStateClass] = useState('modalEntrance');
   const message = gameWon ? 'You Won!' : 'Game Over!';
   const gameResultClass = gameWon ? 'gameWonModal' : 'gameLostModal';
@@ -43,4 +43,4 @@ function GameResultModal({ gameWon, onClick }: GameResultModalProps) {
   );
 }
 
-export default GameResultModal;
+export default ResultModal;

--- a/tests/unit/App.test.jsx
+++ b/tests/unit/App.test.jsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import GameBoard from '@feature/GameBoard/GameBoard';
-import GameDifficultySelector from '@feature/GameDifficultySelector/GameDifficultySelector';
+import DifficultySelect from '@feature/DifficultySelect/DifficultySelect';
 import RemainingFlagsCounter from '@feature/RemainingFlagsCounter/RemainingFlagsCounter';
-import GameResultModal from '@feature/GameResultModal/GameResultModal';
+import ResultModal from '@feature/ResultModal/ResultModal';
 
 // Minimal mock data
 const mockBoard = Array(9).fill(Array(9).fill({}));
@@ -21,7 +21,7 @@ describe('App Component', () => {
 
   it('renders the difficulty selector', () => {
     const { getByTestId } = render(
-      <GameDifficultySelector
+      <DifficultySelect
         gameDifficultySettings={mockDifficulty}
         onChange={() => {}}
       />
@@ -38,7 +38,7 @@ describe('App Component', () => {
 
   it('renders a result modal', () => {
     const { getByTestId } = render(
-      <GameResultModal isOpen={true} onClose={() => {}} result='win' />
+      <ResultModal isOpen={true} onClose={() => {}} result='win' />
     );
     expect(getByTestId('result-modal')).toBeTruthy();
   });


### PR DESCRIPTION
## Description
This PR is for renaming 2 components in Minesweeper from `GameDifficultySelector` to `DifficultySelect` and `GameResultModal` to `ResultModal`.

## Type of Change
- [x] Refactoring (no functional changes)

## Testing
- [x] I have tested these changes locally
- [x] I have tested these changes in multiple browsers/environments if applicable

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if needed

## How to Test

Run `npm test` to validate that the test files successfully pass.


